### PR TITLE
Fix data type of middle array index in calculate_summed_power

### DIFF
--- a/pyimq/filters.py
+++ b/pyimq/filters.py
@@ -276,7 +276,7 @@ class FrequencyQuality(Filter):
         sum = numpy.zeros(self.power.shape[0])
         for i in range(len(self.power.shape)):
             sum += numpy.sum(self.power, axis=i)
-        zero = floor(float(sum.size)/2)
+        zero = int(floor(float(sum.size)/2))
         sum[zero+1:] = sum[zero+1:]+sum[:zero-1][::-1]
         sum = sum[zero:]
         dx = self.data.get_spacing()[0]

--- a/pyimq/myimage.py
+++ b/pyimq/myimage.py
@@ -16,7 +16,7 @@ import argparse
 from PIL import Image
 from PIL.TiffImagePlugin import X_RESOLUTION, Y_RESOLUTION
 from matplotlib import pyplot as plt
-from math import log10
+from math import log10, ceil, floor
 
 
 def get_options(parser):
@@ -194,17 +194,17 @@ class MyImage(object):
 
     def crop_to_rectangle(self):
         """
-        Crop the image into a rectangle. This is sometimes useful, especially
+        Crop the image into a square. This is sometimes useful, especially
         in methods employing FFT.
         """
         dims = self.images.shape
 
         if dims[0] > dims[1]:
-            diff = int(0.5*(dims[0]-dims[1]))
-            self.images = self.images[diff: -diff, :]
+            diff = 0.5*(dims[0]-dims[1])
+            self.images = self.images[int(ceil(diff)): -int(floor(diff)), :]
         elif dims[1] > dims[0]:
-            diff = int(0.5*(dims[1]-dims[0]))
-            self.images = self.images[:, diff: -diff]
+            diff = 0.5*(dims[1]-dims[0])
+            self.images = self.images[:, int(ceil(diff)): -int(floor(diff))]
 
     def resize(self, size):
         """


### PR DESCRIPTION
You cannot index by a float even if the floating point part is zero. Just casting to int should fix it.

It's probably some semantic that changed in an update to numpy.